### PR TITLE
only use security header on certain endpoints

### DIFF
--- a/app/src/authz_openapi.yaml
+++ b/app/src/authz_openapi.yaml
@@ -6,8 +6,6 @@ info:
 servers:
   - url: http://localhost:1235/authz
   - url: /authz
-security:
-  - bearerAuth: []
 paths:
   /service-info:
     get:
@@ -33,6 +31,8 @@ paths:
       summary: List users in group_id
       description: List users in group_id
       operationId: authz_operations.list_group
+      security:
+      - bearerAuth: []
       responses:
         200:
           description: Success
@@ -47,6 +47,8 @@ paths:
     get:
       summary: List registered services
       operationId: authz_operations.list_services
+      security:
+      - bearerAuth: []
       responses:
         200:
           description: Success
@@ -59,6 +61,8 @@ paths:
     post:
       summary: Register service in authorization system
       operationId: authz_operations.add_service
+      security:
+      - bearerAuth: []
       requestBody:
         $ref: '#/components/requestBodies/ServiceRegistrationRequest'
       responses:
@@ -78,6 +82,8 @@ paths:
     get:
       summary: Get registered service
       operationId: authz_operations.get_service
+      security:
+      - bearerAuth: []
       responses:
         200:
           description: Success
@@ -88,6 +94,8 @@ paths:
     delete:
       summary: Remove registered service
       operationId: authz_operations.remove_service
+      security:
+      - bearerAuth: []
       responses:
         200:
           description: Success
@@ -142,6 +150,8 @@ paths:
       summary: Add authorization information for a study
       description: Add authorization information for a study
       operationId: authz_operations.add_study_authorization
+      security:
+      - bearerAuth: []
       requestBody:
         $ref: '#/components/requestBodies/StudyAuthorizationRequest'
       responses:
@@ -155,6 +165,8 @@ paths:
       summary: List registered studies
       description: List studies authorized on server
       operationId: authz_operations.list_study_authorizations
+      security:
+      - bearerAuth: []
       responses:
         200:
           description: Success
@@ -177,6 +189,8 @@ paths:
       summary: Get authorization information for a study
       description: Get authorization information for a study
       operationId: authz_operations.get_study_authorization
+      security:
+      - bearerAuth: []
       responses:
         200:
           description: Success
@@ -187,6 +201,8 @@ paths:
     delete:
       description: Delete a study
       operationId: authz_operations.remove_study_authorization
+      security:
+      - bearerAuth: []
       responses:
         200:
           description: Success
@@ -207,6 +223,8 @@ paths:
       summary: Look up a PCGL user
       description: Look up a PCGL user
       operationId: authz_operations.lookup_user
+      security:
+      - bearerAuth: []
       responses:
         200:
           description: Success
@@ -229,6 +247,8 @@ paths:
       summary: List user authorizations
       description: List authorizations for a user. If the pcgl_id is `me`, returns the information for the user associated with the bearer token.
       operationId: authz_operations.list_authz_for_user
+      security:
+      - bearerAuth: []
       responses:
         200:
           description: Success
@@ -246,6 +266,8 @@ paths:
       summary: Add a study authorization for a user
       description: Authorize a study for a user (or update a study auth for a user)
       operationId: authz_operations.authorize_study_for_user
+      security:
+      - bearerAuth: []
       requestBody:
         $ref: '#/components/requestBodies/DACAuthorizationRequest'
       responses:
@@ -273,6 +295,8 @@ paths:
       summary: Is a user authorized for a study?
       description: Is a user authorized for a study?
       operationId: authz_operations.get_study_for_user
+      security:
+      - bearerAuth: []
       responses:
         200:
           description: Success
@@ -284,6 +308,8 @@ paths:
       summary: Remove a study authorization for a user
       description: Remove a study for a user
       operationId: authz_operations.remove_study_for_user
+      security:
+      - bearerAuth: []
       responses:
         200:
           description: Success
@@ -299,6 +325,8 @@ paths:
       summary: Is the authorized user allowed to perform the requested action?
       description: Returns whether a user is allowed to perform the requested action on the specified datasets
       operationId: authz_operations.is_allowed
+      security:
+      - bearerAuth: []
       requestBody:
         $ref: '#/components/requestBodies/ActionAuthorizationRequest'
       responses:
@@ -314,6 +342,8 @@ paths:
     post:
       summary: Reload users and groups from COManage
       operationId: authz_operations.reload_comanage
+      security:
+      - bearerAuth: []
       responses:
         200:
           description: Success


### PR DESCRIPTION
Instead of putting `security` at the root level, put it on all operations except `/service-info` and `/service/verify`.