### PR TITLE
Bugs in uuid issuing and returning

### DIFF
--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -321,7 +321,6 @@ def list_services():
         for service_id in services:
             response, status_code = get_service_store_secret("opa", key=f"services/{service_id}")
             if status_code == 200:
-                response.pop("service_uuid")
                 result.append(response)
     return result, 200
 

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -80,7 +80,14 @@ def list_group(group_id):
 def list_services():
     try:
         if auth.is_site_admin(connexion.request):
-            return auth.list_services()
+            services, status_code = auth.list_services()
+            if status_code == 200:
+                for service in services:
+                    if "service_uuid" in service:
+                        service.pop("service_uuid")
+                    if "authorization" in service:
+                        service.pop("authorization")
+            return services, status_code
         return {"error": "User is not authorized to list services"}, 403
     except auth.UserTokenError as e:
         return {"error": f"{type(e)} {str(e)}"}, 401


### PR DESCRIPTION
I noticed that I was inconsistent in where service_uuids are returned.

* When adding or updating a service, a new service_uuid should be issued. This is for security.
* Only remove the uuid from the http versions of the calls, not from the auth versions.