### PR TITLE
Allow site admins to bypass service token check

### DIFF
--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -190,7 +190,7 @@ def get_opa_permissions(request=None, user_pcglid=None, method=None, path=None, 
         permissions = response.json()["result"]
 
         # if this request is to check for site admin, just return here
-        if assume_site_admin:
+        if assume_site_admin or is_site_admin(request):
             return permissions, 200
 
         # check to see if the request has the needed headers:
@@ -240,6 +240,11 @@ def is_site_admin(request):
     Is the user associated with the token a site admin?
     Returns boolean.
     """
+    # first check to see if the PCGL_ADMIN_GROUP is in the token's groups
+    if "token_info" in context and "groups" in context["token_info"]:
+        if PCGL_ADMIN_GROUP in context["token_info"]["groups"]:
+            return True
+
     response, status_code = get_opa_permissions(request=request, assume_site_admin=True)
 
     if status_code == 200:

--- a/app/src/authz_openapi.yaml
+++ b/app/src/authz_openapi.yaml
@@ -358,14 +358,14 @@ components:
     ServiceId:
       in: header
       name: X-Service-Id
-      required: true
+      required: false
       schema:
         type: string
       description: ID of a registered service
     ServiceToken:
       in: header
       name: X-Service-Token
-      required: true
+      required: false
       schema:
         type: string
       description: service token created for the service specified by X-Service-Id

--- a/app/tests/test_authz.py
+++ b/app/tests/test_authz.py
@@ -162,7 +162,7 @@ def test_service_token(service_uuid):
     # if there is no service provided, this won't work
     response = requests.get(f"{HOST}/user/me", headers=headers)
     print(response.text)
-    assert response.status_code == 400
+    assert response.status_code == 403
 
     headers["X-Service-Id"] = "test"
     headers["X-Service-Token"] = get_service_token(service_uuid)
@@ -255,6 +255,19 @@ def test_get_users(service_uuid, users, user):
     print(response.text)
     assert "userinfo" in response.json()
     assert response.json()["userinfo"]["pcgl_id"] == users[user]["pcglid"]
+
+
+def test_admin_user(users):
+    headers = {
+        "Authorization": f"Bearer admin",
+        "X-Test-Mode": os.getenv("TEST_KEY")
+    }
+
+    # get their own info
+    response = requests.get(f"{HOST}/user/me", headers=headers)
+    print(response.text)
+    assert "userinfo" in response.json()
+    assert response.json()["userinfo"]["pcgl_id"] == users["admin"]["pcglid"]
 
 
 def get_dacs():


### PR DESCRIPTION
Fixes https://github.com/Pan-Canadian-Genome-Library/pcgl-authz/issues/48.

If a user is in the admin group, they don't need to provide X-Service-Id or X-Service-Token. A test has been added to confirm this.