### PR TITLE
Add opa logging to healthcheck

### DIFF
--- a/app/permissions_engine/authz.rego
+++ b/app/permissions_engine/authz.rego
@@ -40,3 +40,9 @@ allow if {
 	input.path == ["v1", "data", "service", "verified"]
 	input.method == "POST"
 }
+
+# healthcheck: is the opa_secret accessible?
+allow if {
+	input.path == ["v1", "data", "service", "healthcheck"]
+	input.method == "GET"
+}

--- a/app/permissions_engine/service.rego
+++ b/app/permissions_engine/service.rego
@@ -11,5 +11,11 @@ verified if {
 
 else := false
 
+healthcheck if {
+	data.opa_secret
+}
+
+else := false
+
 
 minus(service, info) := "opa service is running"

--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -96,9 +96,10 @@ def handle_token(token, request=None):
                     x = KV_CACHE.set(token, json.dumps(response.json()), ex=expires_in)
                 return response.json()
             elif response.status_code < 500:
+                logger.info(f"bad oauth response: {response.status_code} {response.text}")
                 raise connexion.exceptions.Unauthorized(detail=f"bad oauth response: {response.status_code} {response.text}")
             else:
-                print(f"auth failure: {response.status_code} {response.text}")
+                logger.info(f"auth failure: {response.status_code} {response.text}")
                 raise connexion.exceptions.NonConformingResponse(detail=f"auth failure: {response.status_code} {response.text}")
     except NoServiceFoundError as e:
         raise connexion.exceptions.Forbidden(detail=str(e))

--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -5,6 +5,9 @@ import uuid
 from connexion.context import context
 import connexion
 import valkey
+import logging
+
+logger = logging.getLogger(__file__)
 
 
 ## Env vars for most auth methods:

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -5,6 +5,9 @@ import auth
 import config
 import json
 import requests
+import logging
+
+logger = logging.getLogger(__file__)
 
 
 app = connexion.AsyncApp(__name__)

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -35,6 +35,17 @@ def healthcheck():
     if "X-Test-Mode" in connexion.request.headers and connexion.request.headers["X-Test-Mode"] == os.getenv("TEST_KEY"):
         service = "test"
     try:
+        response = requests.get(
+            os.getenv("OPA_URL") + "/v1/data/service/healthcheck",
+            json={}
+        )
+        if response.status_code != 200:
+            raise Exception("Couldn't connect to OPA healthcheck")
+        else:
+            if "result" not in response.json() or response.json()["result"] == False:
+                # eventually we want to raise this exception, but for now, just log it so we know
+                #raise Exception("OPA couldn't access its secret")
+                logger.info("OPA couldn't access its secret")
         user_index, status_code = auth.get_service_store_secret(service, key=f"users/index")
         if status_code != 200 or len(user_index) == 0:
             raise Exception("vault failure: couldn't get user index")

--- a/app/src/server.py
+++ b/app/src/server.py
@@ -1,6 +1,9 @@
 import connexion
 
+import logging
+import sys
 
+logging.basicConfig(level=logging.INFO, stream=sys.stdout)
 # Create the application instance
 app = connexion.AsyncApp(__name__)
 


### PR DESCRIPTION
Addresses #69. Turn on python logging to capture state of Opa connection during healthcheck.