### PR TITLE
data_admin instead of site_curator

### DIFF
--- a/app/permissions_engine/calculate.rego
+++ b/app/permissions_engine/calculate.rego
@@ -31,8 +31,12 @@ else if {
 	user_id in groups.admin
 }
 
-site_curator if {
-	user_id in groups.curator
+data_admin := true if {
+	"PCGL_DATA_ADMIN_GROUP" in data.idp.user_info.groups
+}
+
+else if {
+	user_id in groups.data_admin
 }
 
 #
@@ -60,23 +64,23 @@ team_readable_studies contains p if {
 
 # user can read studies that are either team-readable or user-readable
 readable_studies := all_studies if {
-	site_curator
+	data_admin
 }
 
 else := team_readable_studies | user_readable_studies
 
-# user can edit studies that list the user as a study curator
+# user can edit studies that list the user as a data submitter
 study_editable_studies contains p if {
 	some p in all_studies
-	user_pcglid in study_auths[p].study_curators
+	user_pcglid in study_auths[p].data_submitters
 }
 
-# if the user is a site curator, they can curate any study
+# if the user is a data admin, they can curate any study
 editable_studies := all_studies if {
-	site_curator
+	data_admin
 }
 
-# otherwise, the user can curate studies where they're listed as a study curator
+# otherwise, the user can curate studies where they're listed as a data submitter
 else := study_editable_studies
 
 import data.vault.paths as paths
@@ -122,9 +126,9 @@ studies := all_studies if {
 	site_admin
 }
 
-# if user is a curator, they can access studies that allow edit access for them for this method, path
+# if user is a data_admin, they can access studies that allow edit or read access for them for this method, path
 else := accessible_studies if {
-	site_curator
+	data_admin
 }
 
 else := accessible_studies if {

--- a/app/permissions_engine/permissions.rego
+++ b/app/permissions_engine/permissions.rego
@@ -17,7 +17,7 @@ site_admin := data.calculate.site_admin if {
 
 else := false
 
-site_curator := data.calculate.site_curator if {
+data_admin := data.calculate.data_admin if {
 	valid_token
 }
 
@@ -65,7 +65,7 @@ else := false
 
 # if a specific study is in the body, allowed = true if that study is in studies
 # or if the user is a site admin
-# or if the user is a site curator and wants to edit something
+# or if the user is a data admin and wants to edit something
 allowed if {
 	studies[input.body.study] == true
 }
@@ -84,12 +84,12 @@ else if {
 }
 
 else if {
-	site_curator
+	data_admin
 	editable_method_path
 }
 
 else if {
-	site_curator
+	data_admin
 	readable_method_path
 }
 
@@ -114,8 +114,8 @@ user_is_site_admin if {
 
 else := false
 
-user_is_site_curator if {
-	user_id in data.vault.groups.curator
+user_is_data_admin if {
+	user_id in data.vault.groups.data_admin
 }
 
 else := false

--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -32,7 +32,7 @@ PCGL_CLIENT_ID = os.getenv("PCGL_CLIENT_ID", None)
 PCGL_CLIENT_SECRET = os.getenv("PCGL_CLIENT_SECRET", None)
 PCGL_ADMIN_GROUP = os.getenv("PCGL_ADMIN_GROUP", "CO:admins")
 PCGL_MEMBER_GROUP = os.getenv("PCGL_MEMBER_GROUP", "CO:members:active")
-PCGL_CURATOR_GROUP = os.getenv("PCGL_CURATOR_GROUP", "PCGL:site_curators")
+PCGL_DATA_ADMIN_GROUP = os.getenv("PCGL_DATA_ADMIN_GROUP", "PCGL:data-admin")
 
 class AuthzError(Exception):
     pass
@@ -564,7 +564,7 @@ def list_authz_for_user(pcgl_id, service=SERVICE_NAME):
             result["study_authorizations"]["editable_studies"] = permissions["editable_studies"]
             result["study_authorizations"]["readable_studies"] = permissions["readable_studies"]
             result["userinfo"]["site_admin"] = permissions["user_is_site_admin"]
-            result["userinfo"]["site_curator"] = permissions["user_is_site_curator"]
+            result["userinfo"]["data_admin"] = permissions["user_is_data_admin"]
         else:
             return permissions, status_code
         groups, status_code = get_groups_for_user(user_dict["comanage_id"], service=service)
@@ -888,9 +888,9 @@ def get_comanage_groups(service=SERVICE_NAME):
             if group["name"] == PCGL_ADMIN_GROUP:
                 data["ids"]["admin"] = str(group["id"])
                 data["admin"] = group["members"]
-            elif group["name"] == PCGL_CURATOR_GROUP:
-                data["ids"]["curator"] = str(group["id"])
-                data["curator"] = group["members"]
+            elif group["name"] == PCGL_DATA_ADMIN_GROUP:
+                data["ids"]["data_admin"] = str(group["id"])
+                data["data_admin"] = group["members"]
             elif group["name"] == PCGL_MEMBER_GROUP:
                 data["ids"]["members"] = str(group["id"])
                 data["members"] = group["members"]

--- a/app/src/authz_openapi.yaml
+++ b/app/src/authz_openapi.yaml
@@ -499,9 +499,9 @@ components:
         study_id:
           type: string
           description: name of the study
-        study_curators:
+        data_submitters:
           type: array
-          description: list of users who are study curators for this study
+          description: list of users who are data submitters for this study
           items:
             type: string
         team_members:
@@ -514,7 +514,7 @@ components:
           description: date study was created, for embargo purposes. This may or may not be the date of ingest.
       required:
         - study_id
-        - study_curators
+        - data_submitters
         - team_members
     DACAuthorization:
       type: object

--- a/app/tests/test_authz.py
+++ b/app/tests/test_authz.py
@@ -461,7 +461,7 @@ def studies():
     return {
       "SYNTHETIC-0": {
         "date_created": "2020-03-01",
-        "study_curators": [
+        "data_submitters": [
             "PCGLuser4"
         ],
         "study_id": "SYNTHETIC-0",
@@ -472,7 +472,7 @@ def studies():
       },
       "SYNTHETIC-1": {
         "date_created": "2020-01-01",
-        "study_curators": [
+        "data_submitters": [
           "PCGLuser1"
         ],
         "study_id": "SYNTHETIC-1",
@@ -482,7 +482,7 @@ def studies():
       },
       "SYNTHETIC-2": {
         "date_created": "2020-03-01",
-        "study_curators": [
+        "data_submitters": [
           "PCGLuser2"
         ],
         "study_id": "SYNTHETIC-2",
@@ -492,7 +492,7 @@ def studies():
       },
       "SYNTHETIC-3": {
         "date_created": "2020-03-01",
-        "study_curators": [
+        "data_submitters": [
           "PCGLuser1",
           "PCGLuser3"
         ],
@@ -505,7 +505,7 @@ def studies():
       },
       "SYNTHETIC-4": {
         "date_created": "2020-03-01",
-        "study_curators": [
+        "data_submitters": [
           "PCGLuser4"
         ],
         "study_id": "SYNTHETIC-4",

--- a/secrets.sh.example
+++ b/secrets.sh.example
@@ -8,6 +8,7 @@ export PCGL_CORE_API_KEY=
 export PCGL_API_URL=https://registry-test.alliancecan.ca
 export PCGL_UID=$(id -u)
 export PCGL_ADMIN_GROUP=CO:admins
+export PCGL_DATA_ADMIN_GROUP=PCGL:data-admin
 export PCGL_MEMBER_GROUP=CO:members:active
 
 # Base URL to serve the Authz API over HTTPS


### PR DESCRIPTION
Addresses Issue #68. PCGL_DATA_ADMIN group replaces CanDIG's site_curator group and aligns with its permissions: data admins should be able to edit/access study data and metadata.

NOTE: PCGL_DATA_ADMIN must be added to secrets.sh or the equivalent configuration.