### PR TITLE
Add service id/token authorization for /reload

### DIFF
--- a/app/src/authz_openapi.yaml
+++ b/app/src/authz_openapi.yaml
@@ -388,6 +388,16 @@ components:
       type: http
       scheme: bearer
       x-bearerInfoFunc: authz_operations.handle_token
+    serviceIdAuth:
+      type: apiKey
+      name: X-Service-Id
+      in: header
+      x-apikeyInfoFunc: authz_operations.handle_service_id_auth
+    serviceTokenAuth:
+      type: apiKey
+      name: X-Service-Token
+      in: header
+      x-apikeyInfoFunc: authz_operations.handle_service_auth
   parameters:
     ServiceId:
       in: header

--- a/app/src/authz_openapi.yaml
+++ b/app/src/authz_openapi.yaml
@@ -377,7 +377,8 @@ paths:
       summary: Reload users and groups from COManage
       operationId: authz_operations.reload_comanage
       security:
-      - bearerAuth: []
+        - serviceIdAuth: []
+          serviceTokenAuth: []
       responses:
         200:
           description: Success

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -19,11 +19,14 @@ def handle_token(token, request=None):
 
 
 def handle_service_id_auth(token, request=None):
-    # if the service doesn't exist, forbid the request
+    service = "opa"
+    if "X-Test-Mode" in request.headers and request.headers["X-Test-Mode"] == os.getenv("TEST_KEY"):
+        service = "test"
     try:
-        auth.get_service(token)
+        # if the service doesn't exist, forbid the request
+        auth.get_service(token, service=service)
     except auth.NoServiceFoundError as e:
-        raise connexion.exceptions.Forbidden(detail=str(e))
+        raise connexion.exceptions.Forbidden(detail=f"service {str(e)}")
     token_info = {
       "active": False
     }
@@ -31,8 +34,11 @@ def handle_service_id_auth(token, request=None):
 
 
 def handle_service_auth(token, request=None):
+    service_namespace = "opa"
+    if "X-Test-Mode" in request.headers and request.headers["X-Test-Mode"] == os.getenv("TEST_KEY"):
+        service_namespace = "test"
     service_id = request.headers['X-Service-Id']
-    if not auth.verify_service_token(service_id, token):
+    if not auth.verify_service_token(service_id, token, service_namespace=service_namespace):
         raise connexion.exceptions.Forbidden(detail=f"service token not valid for service {service_id}")
     token_info = {
       "active": False

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -177,7 +177,10 @@ def remove_service(service_id):
         service = "test"
     try:
         if auth.is_site_admin(connexion.request):
-            return auth.remove_service(service_id, service=service)
+            response, status_code = auth.remove_service(service_id, service=service)
+            if status_code < 300:
+                return None, status_code
+            return response, status_code
         return {"error": "User is not authorized to remove services"}, 403
     except auth.UserTokenError as e:
         return {"error": f"{type(e)} {str(e)}"}, 401

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -12,8 +12,32 @@ logger = logging.getLogger(__file__)
 
 app = connexion.AsyncApp(__name__)
 
+
+# Security scheme handlers
 def handle_token(token, request=None):
     return auth.handle_token(token, request)
+
+
+def handle_service_id_auth(token, request=None):
+    # if the service doesn't exist, forbid the request
+    try:
+        auth.get_service(token)
+    except auth.NoServiceFoundError as e:
+        raise connexion.exceptions.Forbidden(detail=str(e))
+    token_info = {
+      "active": False
+    }
+    return token_info
+
+
+def handle_service_auth(token, request=None):
+    service_id = request.headers['X-Service-Id']
+    if not auth.verify_service_token(service_id, token):
+        raise connexion.exceptions.Forbidden(detail=f"service token not valid for service {service_id}")
+    token_info = {
+      "active": False
+    }
+    return token_info
 
 
 # API endpoints

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -467,20 +467,10 @@ async def is_allowed():
 
 async def reload_comanage():
     try:
-        if not auth.is_site_admin(connexion.request):
-            return {"error": "User is not authorized to reload COManage"}, 403
-    except auth.UserTokenError as e:
-        return {"error": f"{type(e)} {str(e)}"}, 401
-    except auth.AuthzError as e:
-        return {"error": f"{type(e)} {str(e)}"}, 403
-    except Exception as e:
-        return {"error": f"{type(e)} {str(e)}"}, 500
-
-    try:
         open("/app/reload", "x")
     except FileExistsError:
         pass
     except Exception as e:
         return {"error": f"couldn't reload: {type(e)} {str(e)}"}, 500
 
-    return {"status": "reloading: should be complete in a minute or two"}, 200
+    return {"status": "reloading: should be complete within a minute"}, 200

--- a/app/tests/test_authz.py
+++ b/app/tests/test_authz.py
@@ -188,6 +188,34 @@ def test_service_token(service_uuid):
     assert response.status_code == 403
 
 
+def test_reload(service_uuid):
+    headers = {
+        "X-Test-Mode": os.getenv("TEST_KEY")
+    }
+
+    # check that reload works with only service token:
+    headers["X-Service-Id"] = "test"
+    headers["X-Service-Token"] = get_service_token(service_uuid)
+
+    response = requests.post(f"{HOST}/reload", headers=headers)
+    print(response.text)
+    assert response.status_code == 200
+
+    # if the service token is wrong, should be forbidden
+    headers["X-Service-Token"] = "notatoken"
+
+    response = requests.post(f"{HOST}/reload", headers=headers)
+    print(response.text)
+    assert response.status_code == 403
+
+    # if the service isn't valid, should be forbidden
+    headers["X-Service-Id"] = "testtest"
+
+    response = requests.post(f"{HOST}/reload", headers=headers)
+    print(response.text)
+    assert response.status_code == 403
+
+
 def test_add_studies(studies, service_uuid):
     headers = {
         "Authorization": f"Bearer admin",


### PR DESCRIPTION
Addresses #74. Adds ability to use service ID/token authorization for endpoints and enables it for the reload endpoint. Also adds tests to pytest.