### PR TITLE
List groups should be accessible with verified service token

### DIFF
--- a/app/src/authz_openapi.yaml
+++ b/app/src/authz_openapi.yaml
@@ -51,7 +51,9 @@ paths:
       description: List users in group
       operationId: authz_operations.list_group
       security:
-      - bearerAuth: []
+        - bearerAuth: []
+        - serviceIdAuth: []
+          serviceTokenAuth: []
       responses:
         200:
           description: Success

--- a/app/src/authz_openapi.yaml
+++ b/app/src/authz_openapi.yaml
@@ -379,6 +379,7 @@ paths:
       summary: Reload users and groups from COManage
       operationId: authz_operations.reload_comanage
       security:
+        - bearerAuth: []
         - serviceIdAuth: []
           serviceTokenAuth: []
       responses:

--- a/app/src/authz_operations.py
+++ b/app/src/authz_operations.py
@@ -94,9 +94,13 @@ def list_group(group_id):
     if "X-Test-Mode" in connexion.request.headers and connexion.request.headers["X-Test-Mode"] == os.getenv("TEST_KEY"):
         service = "test"
     try:
-        if auth.is_action_allowed_for_study(connexion.request, method="GET", path=f"group/{group_id}"):
+        if "Authorization" in connexion.request.headers:
+            if auth.is_action_allowed_for_study(connexion.request, method="GET", path=f"group/{group_id}"):
+                return auth.list_group(group_id)
+            return {"error": "User is not authorized to list groups"}, 403
+        else:
+            # we got here with a verified service token
             return auth.list_group(group_id)
-        return {"error": "User is not authorized to list groups"}, 403
     except auth.UserTokenError as e:
         return {"error": f"{type(e)} {str(e)}"}, 401
     except auth.AuthzError as e:


### PR DESCRIPTION
Addresses the first part of #70. Also adds back admin access to the /reload endpoint; I didn't mean to take that out when I added service token authz to that.