### PR TITLE
Set up opa's files before launching other containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,6 @@ RUN chmod 777 /vault/data
 WORKDIR /app/
 RUN chown -R pcgl:pcgl /app
 
-RUN mkdir -p /permissions_engine
-RUN chown -R pcgl:pcgl /permissions_engine
-
 USER pcgl
 
 RUN curl -L -o opa https://openpolicyagent.org/downloads/v1.1.0/opa_linux_amd64_static

--- a/Dockerfile.setup
+++ b/Dockerfile.setup
@@ -1,0 +1,23 @@
+ARG venv_python=3.12
+FROM python:${venv_python}
+
+LABEL Maintainer="PCGL Project"
+
+USER root
+
+RUN groupadd -r pcgl && useradd -rm pcgl -g pcgl
+
+COPY app/ /app/
+
+WORKDIR /app/
+RUN chown -R pcgl:pcgl /app
+
+RUN mkdir -p /permissions_engine
+RUN chown -R pcgl:pcgl /permissions_engine
+
+USER pcgl
+
+RUN curl -L -o opa https://openpolicyagent.org/downloads/v1.1.0/opa_linux_amd64_static
+
+RUN chmod 755 ./opa
+

--- a/app/dev.entrypoint.sh
+++ b/app/dev.entrypoint.sh
@@ -6,21 +6,8 @@ set -Euo pipefail
 
 
 if [[ -f "/app/initial_setup" ]]; then
-
-    cp -r /app/permissions_engine/* /permissions_engine/
-    chmod 777 /permissions_engine
-
     mkdir /app/data
     chmod 777 /app/data
-
-    # set up our default values
-    sed -i s@PCGL_ADMIN_GROUP@$PCGL_ADMIN_GROUP@ /permissions_engine/calculate.rego
-
-    token=$(dd if=/dev/urandom bs=1 count=16 2>/dev/null | base64 | tr -d '\n\r+' | sed s/[^A-Za-z0-9]//g)
-    echo { \"opa_secret\": \"$token\" } > /permissions_engine/opa_secret.json
-    # set up vault URL and namespace
-    sed -i s@VAULT_URL@$VAULT_URL@ /permissions_engine/vault.rego
-    sed -i s@VAULT_NAMESPACE@$VAULT_NAMESPACE@ /permissions_engine/vault.rego
 
     echo "initializing stores"
     python3 /app/initialize_vault_store.py

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -4,21 +4,8 @@ set -Euo pipefail
 
 
 if [[ -f "/app/initial_setup" ]]; then
-
-    cp -r /app/permissions_engine/* /permissions_engine/
-    chmod 777 /permissions_engine
-
     mkdir /app/data
     chmod 777 /app/data
-
-    # set up our default values
-    sed -i s@PCGL_ADMIN_GROUP@$PCGL_ADMIN_GROUP@ /permissions_engine/calculate.rego
-
-    token=$(dd if=/dev/urandom bs=1 count=16 2>/dev/null | base64 | tr -d '\n\r+' | sed s/[^A-Za-z0-9]//g)
-    echo { \"opa_secret\": \"$token\" } > /permissions_engine/opa_secret.json
-    # set up vault URL and namespace
-    sed -i s@VAULT_URL@$VAULT_URL@ /permissions_engine/vault.rego
-    sed -i s@VAULT_NAMESPACE@$VAULT_NAMESPACE@ /permissions_engine/vault.rego
 
     echo "initializing stores"
     python3 /app/initialize_vault_store.py

--- a/app/refresh_stores.py
+++ b/app/refresh_stores.py
@@ -11,26 +11,24 @@ logger = logging.getLogger(__file__)
 
 # get the token for the opa store
 try:
-    with open("/permissions_engine/opa_secret.json") as f:
-        opa_json = json.load(f)
-        headers = {
-            "X-Opa": opa_json["opa_secret"],
-            "Content-Type": "application/json; charset=utf-8"
-        }
+    headers = {
+        "X-Opa": os.getenv('OPA_SECRET'),
+        "Content-Type": "application/json; charset=utf-8"
+    }
 
-        # OPA Role-ID
-        opa_role_id = get_secret_file_value_or_env("/home/pcgl/opa-roleid", "OPA_ROLEID")
-        payload = f"{{\"token\": \"{get_vault_token_for_service("opa", role_id=opa_role_id)}\"}}"
-        response = requests.put(url=f"{os.getenv('OPA_URL')}/v1/data/opa_token", headers=headers, data=payload)
+    # OPA Role-ID
+    opa_role_id = get_secret_file_value_or_env("/home/pcgl/opa-roleid", "OPA_ROLEID")
+    payload = f"{{\"token\": \"{get_vault_token_for_service("opa", role_id=opa_role_id)}\"}}"
+    response = requests.put(url=f"{os.getenv('OPA_URL')}/v1/data/opa_token", headers=headers, data=payload)
+    logger.info(f"Updated opa_token: {response.status_code} {response.text}")
+
+    # TODO: can we remove this? Feel that this should be in tests rather than baked in
+    # Test Role-ID
+    test_role_id = get_secret_file_value_or_env("/home/pcgl/test-roleid", "TEST_ROLEID")
+    if test_role_id:
+        payload = f"{{\"token\": \"{get_vault_token_for_service("test", role_id=test_role_id)}\"}}"
+        response = requests.put(url=f"{os.getenv('OPA_URL')}/v1/data/test_token", headers=headers, data=payload)
         logger.info(f"Updated opa_token: {response.status_code} {response.text}")
-
-        # TODO: can we remove this? Feel that this should be in tests rather than baked in
-        # Test Role-ID
-        test_role_id = get_secret_file_value_or_env("/home/pcgl/test-roleid", "TEST_ROLEID")
-        if test_role_id:
-            payload = f"{{\"token\": \"{get_vault_token_for_service("test", role_id=test_role_id)}\"}}"
-            response = requests.put(url=f"{os.getenv('OPA_URL')}/v1/data/test_token", headers=headers, data=payload)
-            logger.info(f"Updated opa_token: {response.status_code} {response.text}")
     logger.info(reload_comanage())
 except Exception as e:
     logger.error(str(e))

--- a/app/setup.sh
+++ b/app/setup.sh
@@ -7,7 +7,7 @@ sed -i s@PCGL_ADMIN_GROUP@$PCGL_ADMIN_GROUP@ /permissions_engine/calculate.rego
 sed -i s@PCGL_DATA_ADMIN_GROUP@$PCGL_DATA_ADMIN_GROUP@ /permissions_engine/calculate.rego
 
 token=$(dd if=/dev/urandom bs=1 count=16 2>/dev/null | base64 | tr -d '\n\r+' | sed s/[^A-Za-z0-9]//g)
-echo { \"opa_secret\": \"$token\" } > /permissions_engine/opa_secret.json
+echo { \"opa_secret\": \"$OPA_SECRET\" } > /permissions_engine/opa_secret.json
 # set up vault URL and namespace
 sed -i s@VAULT_URL@$VAULT_URL@ /permissions_engine/vault.rego
 sed -i s@VAULT_NAMESPACE@$VAULT_NAMESPACE@ /permissions_engine/vault.rego

--- a/app/setup.sh
+++ b/app/setup.sh
@@ -1,0 +1,13 @@
+mkdir -p /permissions_engine
+cp -r /app/permissions_engine/* /permissions_engine/
+chmod 777 /permissions_engine
+
+# set up our default values
+sed -i s@PCGL_ADMIN_GROUP@$PCGL_ADMIN_GROUP@ /permissions_engine/calculate.rego
+sed -i s@PCGL_DATA_ADMIN_GROUP@$PCGL_DATA_ADMIN_GROUP@ /permissions_engine/calculate.rego
+
+token=$(dd if=/dev/urandom bs=1 count=16 2>/dev/null | base64 | tr -d '\n\r+' | sed s/[^A-Za-z0-9]//g)
+echo { \"opa_secret\": \"$token\" } > /permissions_engine/opa_secret.json
+# set up vault URL and namespace
+sed -i s@VAULT_URL@$VAULT_URL@ /permissions_engine/vault.rego
+sed -i s@VAULT_NAMESPACE@$VAULT_NAMESPACE@ /permissions_engine/vault.rego

--- a/app/setup.sh
+++ b/app/setup.sh
@@ -6,7 +6,6 @@ chmod 777 /permissions_engine
 sed -i s@PCGL_ADMIN_GROUP@$PCGL_ADMIN_GROUP@ /permissions_engine/calculate.rego
 sed -i s@PCGL_DATA_ADMIN_GROUP@$PCGL_DATA_ADMIN_GROUP@ /permissions_engine/calculate.rego
 
-token=$(dd if=/dev/urandom bs=1 count=16 2>/dev/null | base64 | tr -d '\n\r+' | sed s/[^A-Za-z0-9]//g)
 echo { \"opa_secret\": \"$OPA_SECRET\" } > /permissions_engine/opa_secret.json
 # set up vault URL and namespace
 sed -i s@VAULT_URL@$VAULT_URL@ /permissions_engine/vault.rego

--- a/app/src/auth.py
+++ b/app/src/auth.py
@@ -907,6 +907,8 @@ def get_comanage_groups(service=SERVICE_NAME):
 
 def reload_comanage(service=SERVICE_NAME):
     logger.info("RELOAD")
+    result = {"users": []}
+
     cached_groups, status_code = get_service_store_secret(service, key="groups")
     if status_code != 200:
         cached_groups = {"members": [], "ids": {}, "index": {}}
@@ -914,13 +916,13 @@ def reload_comanage(service=SERVICE_NAME):
     comanage_groups, status_code = get_comanage_groups(service=service)
     if status_code == 200:
         comanage_groups, status_code = set_service_store_secret(service, key="groups", value=json.dumps(comanage_groups))
+        result["groups"] = comanage_groups
     else:
         return {"error": f"failed to save groups: {comanage_groups}"}, status_code
-    result = []
     # initialize new users:
     try:
         for member in reversed(comanage_groups["members"]):
-            result.append(get_user_record(member, force=True, service=service))
+            result["users"].append(get_user_record(member, force=True, service=service))
     except Exception as e:
         return {"error": f"failed to save users: {type(e)} {str(e)}"}, status_code
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,25 @@ volumes:
   valkey-data:
 
 services:
+  setup:
+    build:
+      context: .
+      dockerfile:
+        Dockerfile.setup
+      args:
+        venv_python: "3.12"
+    volumes:
+      - auth-data:/permissions_engine
+    environment:
+      VAULT_URL: http://vault:8200
+      VAULT_NAMESPACE: ${VAULT_NAMESPACE}
+      PCGL_ADMIN_GROUP: ${PCGL_ADMIN_GROUP}
+      PCGL_DATA_ADMIN_GROUP: ${PCGL_DATA_ADMIN_GROUP}
+      PCGL_MEMBER_GROUP: ${PCGL_MEMBER_GROUP}
+    entrypoint:
+      - "bash"
+      - "/app/setup.sh"
+
   flask:
     build:
       context: .
@@ -33,6 +52,7 @@ services:
       PCGL_COID: ${PCGL_COID}
       PCGL_API_URL: ${PCGL_API_URL}
       PCGL_ADMIN_GROUP: ${PCGL_ADMIN_GROUP}
+      PCGL_DATA_ADMIN_GROUP: ${PCGL_DATA_ADMIN_GROUP}
       PCGL_MEMBER_GROUP: ${PCGL_MEMBER_GROUP}
       TEST_KEY: usethistestkey
       HOST: http://localhost:1235
@@ -54,9 +74,12 @@ services:
       - "--log-level=info"
       - "--authentication=token"
       - "--authorization=basic"
-      - "-s"
       - "--addr=0.0.0.0:8181"
+      - "-s"
       - "/permissions_engine/"
+    depends_on:
+      setup:
+        condition: service_completed_successfully
 
   vault:
     image: openbao/openbao:2.5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     environment:
       VAULT_URL: http://vault:8200
       VAULT_NAMESPACE: ${VAULT_NAMESPACE}
+      OPA_SECRET: "testtest"
       PCGL_ADMIN_GROUP: ${PCGL_ADMIN_GROUP}
       PCGL_DATA_ADMIN_GROUP: ${PCGL_DATA_ADMIN_GROUP}
       PCGL_MEMBER_GROUP: ${PCGL_MEMBER_GROUP}
@@ -37,6 +38,7 @@ services:
       - vault-data:/vault
     environment:
       OPA_URL: http://opa:8181
+      OPA_SECRET: "testtest"
       VAULT_URL: http://vault:8200
       VALKEY_URL: valkey
       VALKEY_USER: ${VALKEY_USER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,6 @@ services:
     ports:
       - 1235:1235
     volumes:
-      - auth-data:/permissions_engine
       - vault-data:/vault
     environment:
       OPA_URL: http://opa:8181


### PR DESCRIPTION
I've added a temporary service that launches just to set up Opa's required files and then set the opa container to depend on that one completing before launching. I assume there is something similar in k8s?

I've also stubbed in something for passing in the OPA_SECRET value as an env var.