### PR TITLE
chore(ci): add github action for opa policies image publish

### DIFF
--- a/.github/workflows/build-publish-opa-images.yml
+++ b/.github/workflows/build-publish-opa-images.yml
@@ -1,0 +1,107 @@
+##### Docker image build & publish
+# This GitHub Action is responsible for building and publishing pcgl-authz as a Docker image to GHCR.
+# Action triggers:
+# - Any commits on 'main': build and publish the image tagged with the short commit sha and 'edge'
+# - Pull requests: build and publish the image tagged with 'pr-<PR number>'
+# - Release: build and publish the image using the release's tag, e.g. 'v1.1.0'
+name: Build and Publish Docker Image for OPA policies
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/pan-canadian-genome-library/pcgl-authz-policies
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      # Checkout
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      # Docker env setup
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # edge metadata
+      - name: Set up edge image metadata
+        id: meta-edge
+        uses: docker/metadata-action@v6
+        if: ${{ github.event_name != 'release' }}
+        with:
+          images: |
+            ${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=edge,enable={{is_default_branch}}
+            type=ref,event=pr
+            type=sha,prefix=sha-
+
+      # edge publish
+      - name: Build and push edge image
+        uses: docker/build-push-action@v7
+        if: ${{ github.event_name != 'release' }}
+        with:
+          context: "."
+          file: "Dockerfile.setup"
+          push: true
+          tags: ${{ steps.meta-edge.outputs.tags }}
+          labels: ${{ steps.meta-edge.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # release metadata
+      - name: Set up release image metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        if: ${{ github.event_name == 'release' }}
+        with:
+          images: |
+            ${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=true
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      # release publish
+      - name: Build and push release image
+        uses: docker/build-push-action@v7
+        if: ${{ github.event_name == 'release' }}
+        with:
+          context: "."
+          file: "Dockerfile.setup"
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile.setup
+++ b/Dockerfile.setup
@@ -16,8 +16,3 @@ RUN mkdir -p /permissions_engine
 RUN chown -R pcgl:pcgl /permissions_engine
 
 USER pcgl
-
-RUN curl -L -o opa https://openpolicyagent.org/downloads/v1.1.0/opa_linux_amd64_static
-
-RUN chmod 755 ./opa
-


### PR DESCRIPTION
Adds a Github Action workflow file to automate build and publishing of OPA policies files init container.

This container is published as `pcgl-authz-policies`, it is built with the same tags/shas as `pcgl-authz`. 

Both images are built on PRs, commits to `main`, and published releases.